### PR TITLE
Don't strip codesign

### DIFF
--- a/azule
+++ b/azule
@@ -864,7 +864,7 @@ if [ -n "$files" ]; then
         find "$dir/$tweakid/Tweak" ! -type l -name "$i" ! -path '*.bundle/*' ! -path '*.framework/*' -exec rsync -a {} Payload/"$appname"/Frameworks \;
         Verbose "Copied $(basename "$i") to app directory" "$(basename "$i") couldn't be copied to app directory" -v -e
 
-        insert_dylib --inplace --weak --all-yes @rpath/"$i" "$executable" &> /dev/null
+        insert_dylib --inplace --weak --no-strip-codesig @rpath/"$i" "$executable" &> /dev/null
         Verbose "Injected $i" "Couldn't inject $i" -e
     done
 


### PR DESCRIPTION
By using `--all-yes`, you are currently implying `--strip-codesign`. This is bad because all entitlement data is lost and you can no longer properly resign the app. This PR makes Azule keep the codesign. If the user wants to remove it, the fakesign option can be used.