### PR TITLE
Don't force AZULE to be in ~/Azule

### DIFF
--- a/azule-functions
+++ b/azule-functions
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Set Environment Variable
-export AZULE=~/Azule
+if [[ -z "$AZULE" ]]; then
+    export AZULE="$HOME/Azule"
+fi
 
 # Add azule commands to PATH
 if [ -d "$AZULE" ]; then


### PR DESCRIPTION
I personally installed Azule in ~/.local/opt/Azule` in WSL2, so having this hardcoded is annoying.

This allows you to export `AZULE` before running `azule-functions`.