### PR TITLE
Honor custom IPA name and generate output with provided name

### DIFF
--- a/azule
+++ b/azule
@@ -1187,9 +1187,7 @@ fi
 
 # GENERATING IPA
 if [ -n "$run" ] || [ -n "$bfplist" ]; then
-    if [ -n "$custom_name" ]; then
-        outdir="$outdir/$name.ipa"
-    fi
+    [[ ! "$name" =~ ".ipa$" ]] && outdir="$outdir/$name.ipa"
 
     # SHORTEN OUTPUT NAME IF NEEDED
     if [[ ${#outdir} -gt 264 ]]; then


### PR DESCRIPTION
Without the fix to honor custom name, azule deletes the parent of output directory since the IPA named directory is not present.